### PR TITLE
use lowercase 'of' for District of Columbia

### DIFF
--- a/lib/madison/states.json
+++ b/lib/madison/states.json
@@ -32,7 +32,7 @@
     "abbr": "DE"
   },
   {
-    "name": "District Of Columbia",
+    "name": "District of Columbia",
     "abbr": "DC"
   },
   {


### PR DESCRIPTION
The name should be 'District of Columbia' with a lowercase 'of.'

References:
https://viaf.org/viaf/143849075/
http://vocab.getty.edu/tgn/7015717
http://www.geonames.org/4138106/district-of-columbia.html

Thanks!